### PR TITLE
Fix the segfault when generate_xml is set to yes.

### DIFF
--- a/src/xmlgen.cpp
+++ b/src/xmlgen.cpp
@@ -620,7 +620,7 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
     if (md->isInline()) t << "yes"; else t << "no";
     t << "\"";
 
-    if (al->refQualifier!=RefQualifierNone)
+    if (al!=0 && al->refQualifier!=RefQualifierNone)
     {
       t << " refqual=\"";
       if (al->refQualifier==RefQualifierLValue) t << "lvalue"; else t << "rvalue";


### PR DESCRIPTION
This PR fixes the segfault that occurs when one tries to generate XML for a CGAL package.